### PR TITLE
Add LaTeX rendering support for posts

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -183,5 +183,6 @@
     "composer:showHelpTab": 1,
     "composer:allowPluginHelp": 1,
     "maxReconnectionAttempts": 5,
-    "reconnectionDelay": 1500
+    "reconnectionDelay": 1500,
+    "supportLaTeX": 1
 }

--- a/install/package.json
+++ b/install/package.json
@@ -80,6 +80,7 @@
         "jsesc": "3.0.2",
         "json2csv": "5.0.7",
         "jsonwebtoken": "8.5.1",
+        "katex": "0.16.9",
         "less": "4.1.3",
         "lodash": "4.17.21",
         "logrotate-stream": "0.2.8",

--- a/test/posts.js
+++ b/test/posts.js
@@ -813,6 +813,24 @@ describe('Post\'s', () => {
             assert.equal(parsedContent, `<a href="${nconf.get('base_url')}/users">test</a> <a href="//youtube.com">youtube</a> some test <img src="${nconf.get('base_url')}/path/to/img"/>`);
             done();
         });
+
+        if (meta.config.supportLaTeX) {
+            it('latex converted HTML should not contain $.$ expressions', (done) => {
+                const content = '<a href="/users">test</a> <a href="youtube.com">youtube</a> some test $2+2$ $sdhajkh + 2^4$ make $ all day <img src="/path/to/img"/>';
+                const texContent = posts.sanitize(content);
+                const inline = /\$(.*?)\$/g;
+                assert(!inline.test(texContent));
+                done();
+            });
+
+            it('latex converted HTML should not contain $.$ expressions', (done) => {
+                const content = '<a href="/users">test</a> <a href="youtube.com">youtube</a> some test $$2+2$$ $$sdhajkh + 2^4$$ make $ all day <img src="/path/to/img"/>';
+                const texContent = posts.sanitize(content);
+                const display = /\$\$(.*?)\$\$/g;
+                assert(!display.test(texContent));
+                done();
+            });
+        }
     });
 
     describe('socket methods', () => {

--- a/themes/nodebb-theme-persona/templates/header.tpl
+++ b/themes/nodebb-theme-persona/templates/header.tpl
@@ -3,6 +3,7 @@
 <head>
     <title>{browserTitle}</title>
     {{{each metaTags}}}{function.buildMetaTag}{{{end}}}
+    <link rel="stylesheet" href="https://unpkg.com/katex@0.12.0/dist/katex.min.css" />
     <link rel="stylesheet" type="text/css" href="{relative_path}/assets/client{{{if bootswatchSkin}}}-{bootswatchSkin}{{{end}}}.css?{config.cache-buster}" />
     {{{each linkTags}}}{function.buildLinkTag}{{{end}}}
 


### PR DESCRIPTION
Resolves #17
- After trying multiple packages offering TeX rendering in JavaScript (e.g. LaTeX.js, MathJax), I found KaTeX was the main package that supported server-side rendering.
- Since the rendering does not automatically search for delimiters, I implemented this manually with regexes, as recommended on the developers' Github.
- Added CSS style sheet to improve math symbol rendering.
- Found an HTML sanitizer for posts that I decided to couple the LaTeX service with, since both involve modifications to the end HTML.
- Created json field for controlling rendering behavior.
- Added automated tests to check that regex expression correctly converted to math.

To-do:
- Should create separate dedicated function for rendering LaTeX and understand where best to call it on post content.
- Currently TeX rendering works for posts and previews, but not for sidebar previews of posts.