### PR TITLE
Remove reputation requirement for nonstudent posts

### DIFF
--- a/src/privileges/categories.js
+++ b/src/privileges/categories.js
@@ -3,6 +3,7 @@
 
 const _ = require('lodash');
 
+const assert = require('assert');
 const categories = require('../categories');
 const user = require('../user');
 const groups = require('../groups');
@@ -116,12 +117,20 @@ privsCategories.isAdminOrMod = async function (cid, uid) {
     return isAdmin || isMod;
 };
 
+/*  @param uid : number
+    @ return isInstructorOrTA : boolean
+*/
 privsCategories.isInstructorOrTA = async function (uid) {
+    assert.strictEqual(typeof parseInt(uid, 10), 'number');
+
     const [isInstructor, isTA] = await Promise.all([
         user.isInstructor(uid),
         user.isTA(uid),
     ]);
-    return isInstructor || isTA;
+    const isInstructorOrTA = (isInstructor || isTA);
+
+    assert.strictEqual(typeof isInstructorOrTA, 'boolean');
+    return isInstructorOrTA;
 };
 
 privsCategories.isUserAllowedTo = async function (privilege, cid, uid) {

--- a/src/privileges/categories.js
+++ b/src/privileges/categories.js
@@ -122,7 +122,7 @@ privsCategories.isInstructorOrTA = async function (uid) {
         user.isTA(uid),
     ]);
     return isInstructor || isTA;
-}
+};
 
 privsCategories.isUserAllowedTo = async function (privilege, cid, uid) {
     if ((Array.isArray(privilege) && !privilege.length) || (Array.isArray(cid) && !cid.length)) {

--- a/src/privileges/categories.js
+++ b/src/privileges/categories.js
@@ -116,6 +116,14 @@ privsCategories.isAdminOrMod = async function (cid, uid) {
     return isAdmin || isMod;
 };
 
+privsCategories.isInstructorOrTA = async function (uid) {
+    const [isInstructor, isTA] = await Promise.all([
+        user.isInstructor(uid),
+        user.isTA(uid),
+    ]);
+    return isInstructor || isTA;
+}
+
 privsCategories.isUserAllowedTo = async function (privilege, cid, uid) {
     if ((Array.isArray(privilege) && !privilege.length) || (Array.isArray(cid) && !cid.length)) {
         return [];

--- a/src/privileges/users.js
+++ b/src/privileges/users.js
@@ -11,6 +11,16 @@ const helpers = require('./helpers');
 
 const privsUsers = module.exports;
 
+privsUsers.isInstructor = async function (uid) {
+    const accountType = await user.getUserField(uid, 'accounttype');
+    return accountType == 'instructor'
+};
+
+privsUsers.isTA = async function (uid) {
+  const accountType = await user.getUserField(uid, 'accounttype');
+  return accountType == 'TA'
+};
+
 privsUsers.isAdministrator = async function (uid) {
     return await isGroupMember(uid, 'administrators');
 };

--- a/src/privileges/users.js
+++ b/src/privileges/users.js
@@ -13,12 +13,12 @@ const privsUsers = module.exports;
 
 privsUsers.isInstructor = async function (uid) {
     const accountType = await user.getUserField(uid, 'accounttype');
-    return accountType == 'instructor'
+    return accountType === 'instructor';
 };
 
 privsUsers.isTA = async function (uid) {
-  const accountType = await user.getUserField(uid, 'accounttype');
-  return accountType == 'TA'
+    const accountType = await user.getUserField(uid, 'accounttype');
+    return accountType === 'TA';
 };
 
 privsUsers.isAdministrator = async function (uid) {

--- a/src/privileges/users.js
+++ b/src/privileges/users.js
@@ -3,6 +3,7 @@
 
 const _ = require('lodash');
 
+const assert = require('assert');
 const user = require('../user');
 const meta = require('../meta');
 const groups = require('../groups');
@@ -11,14 +12,30 @@ const helpers = require('./helpers');
 
 const privsUsers = module.exports;
 
+/*  @param uid : number
+    @return isInstructor : boolean
+*/
 privsUsers.isInstructor = async function (uid) {
+    assert.strictEqual(typeof parseInt(uid, 10), 'number');
+
     const accountType = await user.getUserField(uid, 'accounttype');
-    return accountType === 'instructor';
+    const isInstructor = (accountType === 'instructor');
+
+    assert.strictEqual(typeof isInstructor, 'boolean');
+    return isInstructor;
 };
 
+/*  @param uid : number
+    @return isTA : boolean
+*/
 privsUsers.isTA = async function (uid) {
+    assert.strictEqual(typeof parseInt(uid, 10), 'number');
+
     const accountType = await user.getUserField(uid, 'accounttype');
-    return accountType === 'TA';
+    const isTA = (accountType === 'TA');
+
+    assert.strictEqual(typeof isTA, 'boolean');
+    return isTA;
 };
 
 privsUsers.isAdministrator = async function (uid) {

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 
+const assert = require('assert');
 const groups = require('../groups');
 const plugins = require('../plugins');
 const db = require('../database');
@@ -149,12 +150,28 @@ User.isAdministrator = async function (uid) {
     return await privileges.users.isAdministrator(uid);
 };
 
+/*  @param uid : number
+    @return isInstructor : boolean
+*/
 User.isInstructor = async function (uid) {
-    return await privileges.users.isInstructor(uid);
+    assert.strictEqual(typeof parseInt(uid, 10), 'number');
+
+    const isInstructor = await privileges.users.isInstructor(uid);
+
+    assert.strictEqual(typeof isInstructor, 'boolean');
+    return isInstructor;
 };
 
+/*  @param uid : number
+    @return isTA : boolean
+*/
 User.isTA = async function (uid) {
-    return await privileges.users.isTA(uid);
+    assert.strictEqual(typeof parseInt(uid, 10), 'number');
+
+    const isTA = await privileges.users.isTA(uid);
+
+    assert.strictEqual(typeof isTA, 'boolean');
+    return isTA;
 };
 
 User.isGlobalModerator = async function (uid) {

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -149,6 +149,14 @@ User.isAdministrator = async function (uid) {
     return await privileges.users.isAdministrator(uid);
 };
 
+User.isInstructor = async function (uid) {
+  return await privileges.users.isInstructor(uid);
+}
+
+User.isTA = async function (uid) {
+  return await privileges.users.isTA(uid);
+}
+
 User.isGlobalModerator = async function (uid) {
     return await privileges.users.isGlobalModerator(uid);
 };

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -150,12 +150,12 @@ User.isAdministrator = async function (uid) {
 };
 
 User.isInstructor = async function (uid) {
-  return await privileges.users.isInstructor(uid);
-}
+    return await privileges.users.isInstructor(uid);
+};
 
 User.isTA = async function (uid) {
-  return await privileges.users.isTA(uid);
-}
+    return await privileges.users.isTA(uid);
+};
 
 User.isGlobalModerator = async function (uid) {
     return await privileges.users.isGlobalModerator(uid);

--- a/src/user/posts.js
+++ b/src/user/posts.js
@@ -17,16 +17,17 @@ module.exports = function (User) {
         if (parseInt(uid, 10) === 0) {
             return;
         }
-        const [userData, isAdminOrMod] = await Promise.all([
+        const [userData, isAdminOrMod, isInstructorOrTA] = await Promise.all([
             User.getUserFields(uid, ['uid', 'mutedUntil', 'joindate', 'email', 'reputation'].concat([field])),
             privileges.categories.isAdminOrMod(cid, uid),
+            privileges.categories.isInstructorOrTA(uid),
         ]);
 
         if (!userData.uid) {
             throw new Error('[[error:no-user]]');
         }
 
-        if (isAdminOrMod) {
+        if (isAdminOrMod || isInstructorOrTA) {
             return;
         }
 

--- a/src/user/posts.js
+++ b/src/user/posts.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const db = require('../database');
 const meta = require('../meta');
 const privileges = require('../privileges');
@@ -13,7 +14,17 @@ module.exports = function (User) {
         await isReady(uid, cid, 'lastqueuetime');
     };
 
+    /*  @param uid : number
+        @param cid : number
+        @param field : string
+
+        @return Null
+    */
     async function isReady(uid, cid, field) {
+        assert.strictEqual(typeof parseInt(uid, 10), 'number');
+        assert.strictEqual(typeof parseInt(cid, 10), 'number');
+        assert.strictEqual(typeof field, 'string');
+
         if (parseInt(uid, 10) === 0) {
             return;
         }


### PR DESCRIPTION
Resolves #15 

* Created functions that check if a user is a TA, instructor, or either.
* Checks if user is a TA or an instructor right before they create a post, allowing them to bypass the minimum reputation check if they are.
* Added test cases that creates three different types of accounts: student, TA, and instructor. Checks that the student is forced to wait if they post before the post delay threshold if they have no reputation, but the TA and instructors should be able to create new posts regardless of their reputation.

To do:
* Create TA and instructor groups and add users to those groups automatically when they create their account
* Check for group membership to ascertain whether they are a TA/instructor. 